### PR TITLE
Update configuration to new Cerise config format

### DIFF
--- a/api/config.yml
+++ b/api/config.yml
@@ -1,11 +1,13 @@
 compute-resource:
+  refresh: 10
   files:
-    scheme: sftp
+    protocol: sftp
     location: fs0.das5.cs.vu.nl
     path: /home/$CERISE_USERNAME/.cerise
 
   jobs:
-    scheme: slurm
+    protocol: ssh
     location: fs0.das5.cs.vu.nl
+    scheduler: slurm
     cwl-runner: $CERISE_API_FILES/cerise/cwltiny.py
     slots-per-node: 4


### PR DESCRIPTION
Not sure if you want to merge this into develop or into your lie branch or both, the new Cerise Docker should be building right now, so in a few minutes, a docker pull and a rebuild of the specialisation this should actually work.

The change itself is not big, mainly I separated the protocol used to connect to wherever the jobs are started from the scheduler used to start jobs.